### PR TITLE
Add support for auto submit

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "inquirer": "^3.3.0",
+    "inquirer-autosubmit-prompt": "^0.2.0",
     "rxjs": "^5.5.2",
     "through": "^2.3.8"
   },

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,13 @@ Type: `function`
 
 Function that will be invoked when the user has answered the question.
 
+##### autoSubmit
+
+Type: `function`
+
+Function which accepts the provided value. If returns `true` then the value will be submitted automatically.
+
+
 
 ## License
 


### PR DESCRIPTION
This is a support for https://github.com/sindresorhus/np/issues/291 but I think it's a good feature for listr-input.

To enable auto submit I created a new prompt https://github.com/yaodingyd/inquirer-autosubmit-prompt which combine `password` and `input` (we all know it's just a transform difference) and add 3 extra line here: 

https://github.com/yaodingyd/inquirer-autosubmit-prompt/blob/e1714d0e49152b7960703991645cdbccf8163eb9/index.js#L131-L134
